### PR TITLE
49 - Correct virfusion default checking

### DIFF
--- a/src/Virtfusion/ApiClient.php
+++ b/src/Virtfusion/ApiClient.php
@@ -35,7 +35,8 @@ class ApiClient
                 'Authorization' => 'Bearer ' . $this->configuration->api_token,
             ],
             'connect_timeout' => 10,
-            'timeout' => $configuration->timeout ?? 120,
+            // If timeout is empty, ie 0 or null, we set it to 120 seconds
+            'timeout' => empty($configuration->timeout) ? 120 : $configuration->timeout,
             'handler' => $handler,
         ]);
     }


### PR DESCRIPTION
Closes #49 

- If Virtfusion config timeout is empty (null or 0), default to 120 seconds