### PR TITLE
51 - Correct OnApp default timeout checking

### DIFF
--- a/src/OnApp/ApiClient.php
+++ b/src/OnApp/ApiClient.php
@@ -36,7 +36,8 @@ class ApiClient
                 'Authorization' => ['Basic ' . $credentials],
             ],
             'connect_timeout' => 10,
-            'timeout' => $configuration->timeout ?? 120,
+            // If timeout is empty, ie 0 or null, we set it to 120 seconds
+            'timeout' => empty($configuration->timeout) ? 120 : $configuration->timeout,
             'handler' => $handler,
         ]);
     }


### PR DESCRIPTION
Closes #51 

- If OnApp config timeout is empty (null or 0), default to 120 seconds