### PR TITLE
Hetzner robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following providers are currently implemented:
   - [Virtuozzo Hybrid Server 7](https://docs.virtuozzo.com/legacy/va61/Virtuozzo_Automator_Agent_XML_API_Reference.pdf)
   - [OnApp](https://docs.onapp.com/apim/6.0)
   - [Virtfusion](https://docs.virtfusion.com/api/)
+  - [Hetzner Robot](https://robot.hetzner.com/doc/webservice/en.html#preface)
 
 ## Functions
 

--- a/src/HetznerRobot/Data/Configuration.php
+++ b/src/HetznerRobot/Data/Configuration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\Servers\HetznerRobot\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Hetzner Robot configuration.
+ *
+ * @property-read string $api_login Login field found in API Login Credentials
+ * @property-read string $api_password Password field found in API Login Credentials
+ * @property-read string $test Use Hetzner Robot API test environment
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'api_login' => ['required', 'string'],
+            'api_password' => ['required', 'string', 'min:3'],
+            'test' => ['nullable', 'boolean']
+        ]);
+    }
+}

--- a/src/HetznerRobot/Data/Configuration.php
+++ b/src/HetznerRobot/Data/Configuration.php
@@ -12,7 +12,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  *
  * @property-read string $api_login Login field found in API Login Credentials
  * @property-read string $api_password Password field found in API Login Credentials
- * @property-read string $test Use Hetzner Robot API test environment
+ * @property-read bool|null $test Use Hetzner Robot API test environment
  */
 class Configuration extends DataSet
 {

--- a/src/HetznerRobot/Provider.php
+++ b/src/HetznerRobot/Provider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Upmind\ProvisionProviders\Servers\HetznerRobot;
 
+use GuzzleHttp\Client;
 use Throwable;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
@@ -54,7 +55,7 @@ class Provider extends Category implements ProviderInterface
             $transactionId = $this->robotApi()->create($params);
 
             // Poll for completion
-            $maxWaitSeconds = 600;
+            $maxWaitSeconds = 60;
             $interval = 30;
             $waited = 0;
 
@@ -321,10 +322,24 @@ class Provider extends Category implements ProviderInterface
 
     protected function robotApi(): RobotApiClient
     {
-        return $this->robotApiClient ??= new RobotApiClient(
-            $this->configuration,
-            $this->getGuzzleHandlerStack()
-        );
+        if ($this->robotApiClient === null) {
+            $this->robotApiClient = new RobotApiClient(
+                new Client([
+                    'base_uri' => 'https://robot-ws.your-server.de',
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                        'User-Agent' => 'Upmind/ProvisionProviders/Servers/HetznerRobotApi',
+                    ],
+                    'auth' => [$this->configuration->api_login, $this->configuration->api_password],
+                    'connect_timeout' => 10,
+                    'timeout' => 30,
+                    'handler' => $this->getGuzzleHandlerStack(),
+                ]),
+                $this->configuration,
+            );
+        }
+
+        return $this->robotApiClient;
     }
 
 

--- a/src/HetznerRobot/Provider.php
+++ b/src/HetznerRobot/Provider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Upmind\ProvisionProviders\Servers\HetznerRobot;
 
-use Illuminate\Support\Arr;
 use Throwable;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
@@ -24,7 +23,7 @@ use Upmind\ProvisionProviders\Servers\HetznerRobot\Data\Configuration;
 class Provider extends Category implements ProviderInterface
 {
     protected Configuration $configuration;
-    protected RobotApiClient|null $robotApiClient = null;
+    protected ?RobotApiClient $robotApiClient = null;
 
     public function __construct(Configuration $configuration)
     {
@@ -223,7 +222,7 @@ class Provider extends Category implements ProviderInterface
                 return $info->setMessage('Virtual server already off');
             }
 
-            $this->robotApi()->shutdown($params->instance_id);
+            $this->robotApi()->toggle($params->instance_id);
 
             return $info->setMessage('Server is shutting down')->setState('Stopping');
         } catch (Throwable $e) {
@@ -247,7 +246,7 @@ class Provider extends Category implements ProviderInterface
                 return $info->setMessage('Virtual server already on');
             }
 
-            $this->robotApi()->start($params->instance_id);
+            $this->robotApi()->toggle($params->instance_id);
 
             return $info->setMessage('Server is booting')->setState('Starting');
         } catch (Throwable $e) {
@@ -339,5 +338,4 @@ class Provider extends Category implements ProviderInterface
     {
         throw $e;
     }
-
 }

--- a/src/HetznerRobot/Provider.php
+++ b/src/HetznerRobot/Provider.php
@@ -327,7 +327,6 @@ class Provider extends Category implements ProviderInterface
                 new Client([
                     'base_uri' => 'https://robot-ws.your-server.de',
                     'headers' => [
-                        'Content-Type' => 'application/json',
                         'User-Agent' => 'Upmind/ProvisionProviders/Servers/HetznerRobotApi',
                     ],
                     'auth' => [$this->configuration->api_login, $this->configuration->api_password],

--- a/src/HetznerRobot/Provider.php
+++ b/src/HetznerRobot/Provider.php
@@ -6,6 +6,7 @@ namespace Upmind\ProvisionProviders\Servers\HetznerRobot;
 
 use GuzzleHttp\Client;
 use Throwable;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionProviders\Servers\Category;
@@ -350,6 +351,10 @@ class Provider extends Category implements ProviderInterface
      */
     protected function handleException(Throwable $e): void
     {
+        if (!$e instanceof ProvisionFunctionError) {
+            $e = new ProvisionFunctionError('Unexpected Provider Error', $e->getCode(), $e);
+        }
+
         throw $e;
     }
 }

--- a/src/HetznerRobot/Provider.php
+++ b/src/HetznerRobot/Provider.php
@@ -222,7 +222,7 @@ class Provider extends Category implements ProviderInterface
                 return $info->setMessage('Virtual server already off');
             }
 
-            $this->robotApi()->toggle($params->instance_id);
+            $this->robotApi()->togglePower($params->instance_id);
 
             return $info->setMessage('Server is shutting down')->setState('Stopping');
         } catch (Throwable $e) {
@@ -246,7 +246,7 @@ class Provider extends Category implements ProviderInterface
                 return $info->setMessage('Virtual server already on');
             }
 
-            $this->robotApi()->toggle($params->instance_id);
+            $this->robotApi()->togglePower($params->instance_id);
 
             return $info->setMessage('Server is booting')->setState('Starting');
         } catch (Throwable $e) {

--- a/src/HetznerRobot/Provider.php
+++ b/src/HetznerRobot/Provider.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\Servers\HetznerRobot;
+
+use Illuminate\Support\Arr;
+use Throwable;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionProviders\Servers\Category;
+use Upmind\ProvisionProviders\Servers\Data\ChangeRootPasswordParams;
+use Upmind\ProvisionProviders\Servers\Data\CreateParams;
+use Upmind\ProvisionProviders\Servers\Data\EmptyResult;
+use Upmind\ProvisionProviders\Servers\Data\GetConnectionParams;
+use Upmind\ProvisionProviders\Servers\Data\ReinstallParams;
+use Upmind\ProvisionProviders\Servers\Data\ResizeParams;
+use Upmind\ProvisionProviders\Servers\Data\ServerIdentifierParams;
+use Upmind\ProvisionProviders\Servers\Data\ServerInfoResult;
+use Upmind\ProvisionProviders\Servers\Data\ConnectionResult;
+use Upmind\ProvisionProviders\Servers\HetznerRobot\Data\Configuration;
+
+
+class Provider extends Category implements ProviderInterface
+{
+    protected Configuration $configuration;
+    protected RobotApiClient|null $robotApiClient = null;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Hetzner Robot')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/hetzner-robot-logo.png')
+            ->setDescription('Deploy and manage Hetzner Robot servers');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function create(CreateParams $params): ServerInfoResult
+    {
+        try {
+            $transactionId = $this->robotApi()->create($params);
+
+            // Poll for completion
+            $maxWaitSeconds = 600;
+            $interval = 30;
+            $waited = 0;
+
+            $serverId = null;
+
+            while ($waited < $maxWaitSeconds) {
+                $serverId = $this->robotApi()->checkTransaction($transactionId);
+
+                if (!empty($serverId)) {
+                    break;
+                }
+
+                sleep($interval);
+                $waited += $interval;
+            }
+
+            if ($serverId == null) {
+
+                $info = [
+                    'instance_id' => $transactionId,
+                    'state' => 'In progress',
+                    'label' => $params->image,
+                    'image' => $params->image,
+                    'size' => $params->size,
+                    'location' => $params->location
+                ];
+                return ServerInfoResult::create($info)->setMessage('Transaction in progress!');
+            }
+
+            $this->robotApi()->updateServerName($serverId, $params->label);
+
+            return $this->getServerInfoResult($serverId)->setMessage('Server created successfully!');
+
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getInfo(ServerIdentifierParams $params): ServerInfoResult
+    {
+        try {
+            return $this->getServerInfoResult($params->instance_id)->setMessage('Server info obtained');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    protected function getServerInfoResult($serverId): ServerInfoResult
+    {
+        $info = $this->robotApi()->getServerInfo($serverId);
+
+        return ServerInfoResult::create($info);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getConnection(GetConnectionParams $params): ConnectionResult
+    {
+        try {
+            $info = $this->getServerInfoResult($params->instance_id);
+
+            if (!$info->ip_address) {
+                $this->errorResult('IP address not found');
+            }
+
+            return ConnectionResult::create()
+                ->setMessage('SSH command generated')
+                ->setType(ConnectionResult::TYPE_SSH)
+                ->setCommand(sprintf('ssh root@%s', $info['ip_address']));
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function changeRootPassword(ChangeRootPasswordParams $params): ServerInfoResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function resize(ResizeParams $params): ServerInfoResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function reinstall(ReinstallParams $params): ServerInfoResult
+    {
+        try {
+            $this->robotApi()->rebuildServer($params->instance_id, $params->image);
+
+            return $this->getServerInfoResult($params->instance_id)->setMessage('Server rebuilding with fresh image/template');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function reboot(ServerIdentifierParams $params): ServerInfoResult
+    {
+        try {
+            $this->robotApi()->reboot($params->instance_id);
+
+            return $this->getServerInfoResult($params->instance_id)->setMessage('Server is rebooting');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function shutdown(ServerIdentifierParams $params): ServerInfoResult
+    {
+        try {
+            $info = $this->getServerInfoResult($params->instance_id);
+
+            if ($info->state === 'off') {
+                return $info->setMessage('Virtual server already off');
+            }
+
+            $this->robotApi()->shutdown($params->instance_id);
+
+            return $info->setMessage('Server is shutting down')->setState('Stopping');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function powerOn(ServerIdentifierParams $params): ServerInfoResult
+    {
+        try {
+            $info = $this->getServerInfoResult($params->instance_id);
+
+            if ($info->state === 'on') {
+                return $info->setMessage('Virtual server already on');
+            }
+
+            $this->robotApi()->start($params->instance_id);
+
+            return $info->setMessage('Server is booting')->setState('Starting');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function suspend(ServerIdentifierParams $params): ServerInfoResult
+    {
+        return $this->shutdown($params)->setSuspended(true);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function unsuspend(ServerIdentifierParams $params): ServerInfoResult
+    {
+        return $this->powerOn($params)->setSuspended(false);
+    }
+
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function attachRecoveryIso(ServerIdentifierParams $params): ServerInfoResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function detachRecoveryIso(ServerIdentifierParams $params): ServerInfoResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function terminate(ServerIdentifierParams $params): EmptyResult
+    {
+        try {
+            $this->getServerInfoResult($params->instance_id);
+
+            $this->robotApi()->destroy($params->instance_id);
+
+            return EmptyResult::create()->setMessage('Server is deleting');
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    protected function robotApi(): RobotApiClient
+    {
+        return $this->robotApiClient ??= new RobotApiClient(
+            $this->configuration,
+            $this->getGuzzleHandlerStack()
+        );
+    }
+
+
+    /**
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    protected function handleException(Throwable $e): void
+    {
+        throw $e;
+    }
+
+}

--- a/src/HetznerRobot/Provider.php
+++ b/src/HetznerRobot/Provider.php
@@ -39,7 +39,7 @@ class Provider extends Category implements ProviderInterface
     {
         return AboutData::create()
             ->setName('Hetzner Robot')
-            ->setLogoUrl('https://api.upmind.io/images/logos/provision/hetzner-robot-logo.png')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/hetzner-logo.svg')
             ->setDescription('Deploy and manage Hetzner Robot servers');
     }
 

--- a/src/HetznerRobot/Provider.php
+++ b/src/HetznerRobot/Provider.php
@@ -55,7 +55,7 @@ class Provider extends Category implements ProviderInterface
             $transactionId = $this->robotApi()->create($params);
 
             // Poll for completion
-            $maxWaitSeconds = 60;
+            $maxWaitSeconds = 600;
             $interval = 30;
             $waited = 0;
 

--- a/src/HetznerRobot/RobotApiClient.php
+++ b/src/HetznerRobot/RobotApiClient.php
@@ -4,17 +4,10 @@ declare(strict_types=1);
 
 namespace Upmind\ProvisionProviders\Servers\HetznerRobot;
 
-use Carbon\Carbon;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\RequestOptions;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Throwable;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Helper;
@@ -47,8 +40,7 @@ class RobotApiClient
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      * @throws \Throwable
      */
-    public function create(
-        CreateParams $params): string
+    public function create(CreateParams $params): string
     {
         $product = $this->findProduct($params->size);
 
@@ -157,15 +149,16 @@ class RobotApiClient
             if (is_string($boot['dist'])) {
                 $image = $boot['dist'];
             }
-        } catch (Throwable) {
+        } catch (Throwable $t) {
+            // Ignore errors for fetching image info
         }
 
         $reset = $this->getReset($serverId);
 
         return [
             'instance_id' => (string)$response['server_number'],
-            'state' => $reset['operating_status'] == 'running' ? 'on' : 'off',
-            'label' => $response['server_name'] ?: 'Null',
+            'state' => $reset['operating_status'] === 'running' ? 'on' : 'off',
+            'label' => $response['server_name'] ?: 'N/A',
             'image' => $image,
             'ip_address' => $response['server_ip'],
             'size' => $response['product'],
@@ -205,23 +198,14 @@ class RobotApiClient
     }
 
     /**
+     * Method to change the power state of the server.
+     * It will turn it `off` if currently `on` and `on` if currently `off`
+     *
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      * @throws \Throwable
      */
-
-    public function shutdown(string $serverId): void
-    {
-        $this->makeRequest("/reset/{$serverId}", ['type' => 'power'], null, 'POST');
-    }
-
-    /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     * @throws \Throwable
-     */
-
-    public function start(string $serverId): void
+    public function toggle(string $serverId): void
     {
         $this->makeRequest("/reset/{$serverId}", ['type' => 'power'], null, 'POST');
     }

--- a/src/HetznerRobot/RobotApiClient.php
+++ b/src/HetznerRobot/RobotApiClient.php
@@ -205,7 +205,7 @@ class RobotApiClient
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      * @throws \Throwable
      */
-    public function toggle(string $serverId): void
+    public function togglePower(string $serverId): void
     {
         $this->makeRequest("/reset/{$serverId}", ['type' => 'power'], null, 'POST');
     }
@@ -218,7 +218,6 @@ class RobotApiClient
 
     public function rebuildServer(string $serverId, string $image): void
     {
-
         $linux = $this->makeRequest("/boot/{$serverId}/linux")['linux'];
 
         if (!in_array($image, $linux['dist'])) {

--- a/src/HetznerRobot/RobotApiClient.php
+++ b/src/HetznerRobot/RobotApiClient.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\Servers\HetznerRobot;
+
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Throwable;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Helper;
+use Upmind\ProvisionProviders\Servers\Data\CreateParams;
+use Upmind\ProvisionProviders\Servers\HetznerRobot\Data\Configuration;
+
+class RobotApiClient
+{
+    protected Configuration $configuration;
+    protected Client $client;
+
+    public function __construct(Configuration $configuration, ?HandlerStack $handler = null)
+    {
+        $this->configuration = $configuration;
+        $this->client = new Client([
+            'base_uri' => 'https://robot-ws.your-server.de',
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/HetznerRobotApi',
+            ],
+            'auth' => [$this->configuration->api_login, $this->configuration->api_password],
+            'connect_timeout' => 10,
+            'timeout' => 30,
+            'handler' => $handler,
+        ]);
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function create(
+        CreateParams $params): string
+    {
+        $product = $this->findProduct($params->size);
+
+        if (!in_array($params->location, $product['location'])) {
+            throw ProvisionFunctionError::create('Location not found')
+                ->withData([
+                    'result_data' => $product,
+                ]);
+        }
+
+        if (!in_array($params->image, $product['dist'])) {
+            throw ProvisionFunctionError::create('Image not found')
+                ->withData([
+                    'result_data' => $product,
+                ]);
+        }
+
+        $body = [
+            'product_id' => $product['id'],
+            'password' => $params->root_password ?: Helper::generatePassword(15),
+            'location' => $params->location,
+            'dist' => $params->image,
+            'addon' => ['primary_ipv4'],
+        ];
+
+        if ($this->configuration->test) {
+            $body['test'] = 'true';
+        }
+
+        $response = $this->makeRequest("/order/server/transaction", null, $body, 'POST');
+
+        if (!$id = $response['transaction']['id']) {
+            throw ProvisionFunctionError::create('Server creation failed')
+                ->withData([
+                    'result_data' => $response,
+                ]);
+        }
+
+        return $id;
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function updateServerName(string $serverId, string $label): void
+    {
+        $this->makeRequest("/server/{$serverId}", [
+            'server_name' => $label
+        ], null, 'POST');
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function checkTransaction(string $transactionId): ?string
+    {
+        $response = $this->makeRequest("/order/server/transaction/{$transactionId}");
+        return $response["transaction"]['server_number'];
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function findProduct($productName): array
+    {
+        foreach ($this->listProducts() as $product) {
+            if ($productName === $product['product']['id']) {
+                return $product['product'];
+            }
+        }
+
+        throw ProvisionFunctionError::create('Product not found')
+            ->withData([
+                'product' => $productName,
+            ]);
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function listProducts(): array
+    {
+        return $this->makeRequest("/order/server/product");
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function getServerInfo($serverId): array
+    {
+        $response = $this->makeRequest("server/{$serverId}")['server'];
+        $image = 'Unknown';
+
+        try {
+            $boot = $this->makeRequest("/boot/{$serverId}/linux/last")['linux'];
+            if (is_string($boot['dist'])) {
+                $image = $boot['dist'];
+            }
+        } catch (Throwable) {
+        }
+
+        $reset = $this->getReset($serverId);
+
+        return [
+            'instance_id' => (string)$response['server_number'],
+            'state' => $reset['operating_status'] == 'running' ? 'on' : 'off',
+            'label' => $response['server_name'] ?: 'Null',
+            'image' => $image,
+            'ip_address' => $response['server_ip'],
+            'size' => $response['product'],
+            'location' => $response['dc'],
+        ];
+    }
+
+    /**
+     * @param $serverId
+     * @return array
+     * @throws Throwable
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    private function getReset($serverId): array
+    {
+        return $this->makeRequest("/reset/{$serverId}")['reset'];
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function destroy(string $serverId): void
+    {
+        $this->makeRequest("/server/{$serverId}/cancellation", ['cancellation_date' => 'now'], null, 'POST');
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function reboot(string $serverId): void
+    {
+        $this->makeRequest("/reset/{$serverId}", ['type' => 'hw'], null, 'POST');
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+
+    public function shutdown(string $serverId): void
+    {
+        $this->makeRequest("/reset/{$serverId}", ['type' => 'power'], null, 'POST');
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+
+    public function start(string $serverId): void
+    {
+        $this->makeRequest("/reset/{$serverId}", ['type' => 'power'], null, 'POST');
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+
+    public function rebuildServer(string $serverId, string $image): void
+    {
+
+        $linux = $this->makeRequest("/boot/{$serverId}/linux")['linux'];
+
+        if (!in_array($image, $linux['dist'])) {
+            throw ProvisionFunctionError::create('Image not found')
+                ->withData([
+                    'result_data' => $linux,
+                ]);
+        }
+
+        $this->makeRequest("/boot/{$serverId}/linux", ['dist' => $image, 'lang' => 'en'], null, 'POST');
+
+        $this->makeRequest("/reset/{$serverId}", ['type' => 'hw'], null, 'POST');
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    public function makeRequest(
+        string  $command,
+        ?array  $params = null,
+        ?array  $body = null,
+        ?string $method = 'GET'
+    ): ?array
+    {
+        try {
+            $requestParams = [];
+
+            if ($params) {
+                $requestParams['query'] = $params;
+            }
+
+            if ($body) {
+                $requestParams['form_params'] = $body;
+            }
+
+            $response = $this->client->request($method, $command, $requestParams);
+            $result = $response->getBody()->getContents();
+
+            $response->getBody()->close();
+
+            if ($result === '') {
+                return null;
+            }
+
+            return $this->parseResponseData($result);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function parseResponseData(string $response): array
+    {
+        $parsedResult = json_decode($response, true);
+
+        if (!$parsedResult) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $response,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
+     */
+    private function handleException(Throwable $e): void
+    {
+        if ($e instanceof ProvisionFunctionError) {
+            throw $e;
+        }
+
+        $errorData = [
+            'exception' => get_class($e),
+        ];
+
+        if ($e instanceof ConnectException) {
+            $errorData['connection_error'] = $e->getMessage();
+            throw ProvisionFunctionError::create('Provider API Connection error', $e)
+                ->withData($errorData);
+        }
+
+        if (($e instanceof ClientException) && $e->hasResponse()) {
+            $response = $e->getResponse();
+            $reason = $response->getReasonPhrase();
+            $responseBody = $response->getBody()->__toString();
+            $responseData = json_decode($responseBody, true);
+
+            $messages = [];
+            $errors = $responseData['error'];
+            foreach ($errors as $key => $value) {
+                if (is_array($value)) {
+                    $messages[] = $key . ': ' . implode(', ', $value);
+                } else {
+                    $messages[] = $key . ': ' . $value;
+                }
+            }
+
+            if ($messages) {
+                $errorMessage = implode(', ', $messages);
+            }
+
+            $errorMessage = sprintf('Provider API error: %s', $errorMessage ?? $reason ?? 'Unknown');
+            throw ProvisionFunctionError::create($errorMessage)
+                ->withData($errorData);
+
+        }
+
+        throw $e;
+    }
+}

--- a/src/HetznerRobot/RobotApiClient.php
+++ b/src/HetznerRobot/RobotApiClient.php
@@ -346,7 +346,7 @@ class RobotApiClient
                 $errorMessage = implode(', ', $messages);
             }
 
-            $errorMessage = sprintf('Provider API error: %s', $errorMessage ?? $reason ?? 'Unknown');
+            $errorMessage = sprintf('Provider API error: %s', $errorMessage ?? $reason);
             throw ProvisionFunctionError::create($errorMessage)
                 ->withData($errorData);
 

--- a/src/HetznerRobot/RobotApiClient.php
+++ b/src/HetznerRobot/RobotApiClient.php
@@ -7,7 +7,6 @@ namespace Upmind\ProvisionProviders\Servers\HetznerRobot;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\HandlerStack;
 use Throwable;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Helper;
@@ -19,20 +18,10 @@ class RobotApiClient
     protected Configuration $configuration;
     protected Client $client;
 
-    public function __construct(Configuration $configuration, ?HandlerStack $handler = null)
+    public function __construct(Client $client, Configuration $configuration)
     {
+        $this->client = $client;
         $this->configuration = $configuration;
-        $this->client = new Client([
-            'base_uri' => 'https://robot-ws.your-server.de',
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/HetznerRobotApi',
-            ],
-            'auth' => [$this->configuration->api_login, $this->configuration->api_password],
-            'connect_timeout' => 10,
-            'timeout' => 30,
-            'handler' => $handler,
-        ]);
     }
 
     /**
@@ -242,8 +231,7 @@ class RobotApiClient
         ?array  $params = null,
         ?array  $body = null,
         ?string $method = 'GET'
-    ): ?array
-    {
+    ): ?array {
         try {
             $requestParams = [];
 
@@ -256,7 +244,7 @@ class RobotApiClient
             }
 
             $response = $this->client->request($method, $command, $requestParams);
-            $result = $response->getBody()->getContents();
+            $result = $response->getBody()->__toString();
 
             $response->getBody()->close();
 

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -20,5 +20,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('servers', 'virtuozzo', Virtuozzo\Provider::class);
         $this->bindProvider('servers', 'onapp', OnApp\Provider::class);
         $this->bindProvider('servers', 'virtfusion', Virtfusion\Provider::class);
+        $this->bindProvider('servers', 'hetzner-robot', HetznerRobot\Provider::class);
     }
 }


### PR DESCRIPTION
Updated #53 

The following functions were implemented for Hetzner Robot API:

- create() - use the Size parameter as the server name (e.g. "AX41-NVMe").
- getInfo()
- getConnection() - Hetzner Robot API does not return the root password after a server is created. So, you need to store password on your side.
- reinstall()
- reboot()
- shutdown()
- powerOn()
- suspend()
- unsuspend()
- terminate()

The following functions aren't supported:

- changeRootPassword()
- resize()
- attachRecoveryIso()
- detachRecoveryIso()