### PR TITLE
ATBE-918: Add cpu_cores, memory_mb, disk_mb to Virtualizor ServerInfoResult

### DIFF
--- a/src/Virtualizor/Provider.php
+++ b/src/Virtualizor/Provider.php
@@ -425,7 +425,10 @@ class Provider extends Category implements ProviderInterface
             ->setLocation($location)
             ->setNode($server['server_name'])
             ->setVirtualizationType($vps['virt'])
-            ->setIpAddress(Arr::first($vps['ips']));
+            ->setIpAddress(Arr::first($vps['ips']))
+            ->setCpuCores(isset($vps['cores']) ? (int)$vps['cores'] : null)
+            ->setMemoryMb(isset($vps['ram']) ? (int)$vps['ram'] : null)
+            ->setDiskMb(isset($vps['space']) ? (int)$vps['space'] * 1024 : null);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Extract resource allocation data from Virtualizor API response in `getInfo()`
- Populate `cpu_cores`, `memory_mb`, and `disk_mb` fields in `ServerInfoResult`

## Changes

| Field | Source | Notes |
|-------|--------|-------|
| `cpu_cores` | `$vps['cores']` | Integer |
| `memory_mb` | `$vps['ram']` | Already in MB |
| `disk_mb` | `$vps['space']` | Converted from GB to MB (`* 1024`) |

## Test plan

- [x] Verify with live Virtualizor credentials that API returns `cores`, `ram`, `space` fields
- [x] Confirm disk space unit conversion (GB → MB) is correct
- [x] Test `getInfo()` returns populated `cpu_cores`, `memory_mb`, `disk_mb`

